### PR TITLE
Add kernel-side event filtering support 

### DIFF
--- a/userspace/falco/app/actions/helpers_inspector.cpp
+++ b/userspace/falco/app/actions/helpers_inspector.cpp
@@ -102,7 +102,7 @@ falco::app::run_result falco::app::actions::open_live_inspector(
 		{
 			falco_logger::log(falco_logger::level::INFO, "Opening '" + source + "' source with modern BPF probe.");
 			falco_logger::log(falco_logger::level::INFO, "One ring buffer every '" + std::to_string(s.config->m_modern_ebpf.m_cpus_for_each_buffer) +  "' CPUs.");
-			inspector->open_modern_bpf(s.syscall_buffer_bytes_size, s.config->m_modern_ebpf.m_cpus_for_each_buffer, true, s.selected_sc_set);
+			inspector->open_modern_bpf(s.syscall_buffer_bytes_size, s.config->m_modern_ebpf.m_cpus_for_each_buffer, true, s.selected_sc_set, s.config->m_modern_ebpf.m_filters);
 		}
 		else if(s.is_ebpf()) /* BPF engine. */
 		{

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -126,6 +126,7 @@ void falco_configuration::load_engine_config(const std::string& config_name, con
 	m_syscall_buf_size_preset = config.get_scalar<int16_t>("syscall_buf_size_preset", DEFAULT_BUF_SIZE_PRESET);
 	m_cpus_for_each_syscall_buffer = config.get_scalar<uint16_t>("modern_bpf.cpus_for_each_syscall_buffer", DEFAULT_CPUS_FOR_EACH_SYSCALL_BUFFER);
 	m_syscall_drop_failed_exit = config.get_scalar<bool>("syscall_drop_failed_exit", DEFAULT_DROP_FAILED_EXIT);
+
 	switch (m_engine_mode)
 	{
 	case engine_kind_t::KMOD:
@@ -629,4 +630,3 @@ void falco_configuration::set_cmdline_option(yaml_helper& config, const std::str
 
 	config.set_scalar(keyval.first, keyval.second);
 }
-

--- a/userspace/falco/configuration.cpp
+++ b/userspace/falco/configuration.cpp
@@ -157,17 +157,17 @@ void falco_configuration::load_engine_config(const std::string& config_name, con
 		m_modern_ebpf.m_drop_failed_exit = config.get_scalar<bool>("engine.modern_ebpf.drop_failed_exit", DEFAULT_DROP_FAILED_EXIT);
 		if (config.is_defined("filters"))
 		{
-			std::list<falco_configuration::filter_config_pre> filters;
-			config.get_sequence<std::list<falco_configuration::filter_config_pre>>(filters, std::string("filters"));
+			std::list<falco_configuration::filter_config_entry> filters;
+			config.get_sequence<std::list<falco_configuration::filter_config_entry>>(filters, std::string("filters"));
 			int filter_index = 0;
-			for (std::list<falco_configuration::filter_config_pre>::iterator it = filters.begin(); it != filters.end(); ++it) 
+			for (std::list<falco_configuration::filter_config_entry>::iterator it = filters.begin(); it != filters.end(); ++it) 
 			{
-				m_modern_ebpf.m_filters[filter_index].m_syscall = it->m_syscall;
-				m_modern_ebpf.m_filters[filter_index].m_arg = it->m_arg;
-				m_modern_ebpf.m_filters[filter_index].m_num_prefixes = (uint16_t) it->m_prefixes.size();
+				m_modern_ebpf.m_filters[filter_index].syscall = it->m_syscall;
+				m_modern_ebpf.m_filters[filter_index].entry.arg_num = it->m_arg_num;
+				m_modern_ebpf.m_filters[filter_index].entry.num_prefixes = (uint16_t) it->m_prefixes.size();
 				int i = 0;
 				for (std::_List_iterator<std::string> prefix_it = it->m_prefixes.begin(); prefix_it!=it->m_prefixes.end(); ++prefix_it) {
-					memcpy(&m_modern_ebpf.m_filters[filter_index].m_prefixes[i][0], (*prefix_it).c_str(), (*prefix_it).length());
+					memcpy(&m_modern_ebpf.m_filters[filter_index].entry.prefixes[i][0], (*prefix_it).c_str(), (*prefix_it).length());
 					i++;
 				}
 				filter_index++;

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -73,10 +73,17 @@ public:
 		bool m_drop_failed_exit;
 	};
 
+	struct filter_config_pre {
+		std::uint32_t m_syscall;
+		std::uint16_t m_arg;
+		std::list<std::string> m_prefixes;
+	};
+
 	struct modern_ebpf_config {
 		uint16_t m_cpus_for_each_buffer;
 		int16_t m_buf_size_preset;
 		bool m_drop_failed_exit;
+		struct filter_config m_filters[16];
 	};
 
 	struct replay_config {
@@ -258,3 +265,44 @@ namespace YAML {
 		}
 	};
 }
+
+namespace YAML {
+	template<>
+	struct convert<falco_configuration::filter_config_pre> {
+
+		static Node encode(const falco_configuration::filter_config_pre & rhs) {
+			Node node;
+			node["syscall"] = rhs.m_syscall;
+			node["arg"] = rhs.m_arg;
+			node["prefixes"] = rhs.m_prefixes;
+			return node;
+		}
+
+		static bool decode(const Node& node, falco_configuration::filter_config_pre & rhs) {
+			if(!node.IsMap())
+			{
+				return false;
+			}
+
+			if(!node["syscall"])
+			{
+				return false;
+			}
+			rhs.m_syscall = node["syscall"].as<std::int32_t>();
+
+			if(!node["arg"])
+			{
+				return false;
+			}
+			rhs.m_arg = node["arg"].as<std::int16_t>();
+
+			if(!node["prefixes"])
+			{
+				return false;
+			}
+			rhs.m_prefixes = node["prefixes"].as<std::list<std::string>>();
+			return true;
+		}
+	};
+}
+

--- a/userspace/falco/configuration.h
+++ b/userspace/falco/configuration.h
@@ -73,9 +73,9 @@ public:
 		bool m_drop_failed_exit;
 	};
 
-	struct filter_config_pre {
+	struct filter_config_entry {
 		std::uint32_t m_syscall;
-		std::uint16_t m_arg;
+		std::uint16_t m_arg_num;
 		std::list<std::string> m_prefixes;
 	};
 
@@ -268,17 +268,17 @@ namespace YAML {
 
 namespace YAML {
 	template<>
-	struct convert<falco_configuration::filter_config_pre> {
+	struct convert<falco_configuration::filter_config_entry> {
 
-		static Node encode(const falco_configuration::filter_config_pre & rhs) {
+		static Node encode(const falco_configuration::filter_config_entry & rhs) {
 			Node node;
 			node["syscall"] = rhs.m_syscall;
-			node["arg"] = rhs.m_arg;
+			node["arg"] = rhs.m_arg_num;
 			node["prefixes"] = rhs.m_prefixes;
 			return node;
 		}
 
-		static bool decode(const Node& node, falco_configuration::filter_config_pre & rhs) {
+		static bool decode(const Node& node, falco_configuration::filter_config_entry & rhs) {
 			if(!node.IsMap())
 			{
 				return false;
@@ -294,7 +294,7 @@ namespace YAML {
 			{
 				return false;
 			}
-			rhs.m_arg = node["arg"].as<std::int16_t>();
+			rhs.m_arg_num = node["arg"].as<std::int16_t>();
 
 			if(!node["prefixes"])
 			{

--- a/userspace/falco/logger.cpp
+++ b/userspace/falco/logger.cpp
@@ -112,9 +112,9 @@ void falco_logger::set_sinsp_logging(bool enable, const std::string& severity, c
 	if (enable)
 	{
 		s_sinsp_logger_prefix = prefix;
-		g_logger.set_severity(decode_sinsp_severity(severity));
-		g_logger.disable_timestamps();
-		g_logger.add_callback_log(
+		libsinsp_logger()->set_severity(decode_sinsp_severity(severity));
+		libsinsp_logger()->disable_timestamps();
+		libsinsp_logger()->add_callback_log(
 			[](std::string&& str, const sinsp_logger::severity sev)
 			{
 				// note: using falco_logger::level ensures that the sinsp
@@ -126,7 +126,7 @@ void falco_logger::set_sinsp_logging(bool enable, const std::string& severity, c
 	}
 	else
 	{
-		g_logger.remove_callback_log();
+		libsinsp_logger()->remove_callback_log();
 	}
 }
 


### PR DESCRIPTION
Parses the filter config if present and passes it to sinsp to process into the shared BPF map (see other PR for that)